### PR TITLE
Improve CounterUsingMithril to use Tachyons and also install libraries from npm modules

### DIFF
--- a/Examples/CounterUsingMithril/.gitignore
+++ b/Examples/CounterUsingMithril/.gitignore
@@ -1,1 +1,2 @@
 web/Script
+web/resources-from-npm

--- a/Examples/CounterUsingMithril/install.sh
+++ b/Examples/CounterUsingMithril/install.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# This script installs NPM dependencies of the CounterUsingMithril project.
+
+# Exit script if a step fails
+set -e
+# Set working directory to script directory
+cd "$(dirname "$0")"
+
+echo "Installing NPM packages for example CounterUsingMithril"
+npm install
+
+echo "Copy Mithril and Tachyons files from npm packages to web/resources-from-npm"
+mkdir -p web/resources-from-npm
+cp ./node_modules/mithril/mithril.js web/resources-from-npm/
+cp ./node_modules/tachyons/css/tachyons.css web/resources-from-npm/

--- a/Examples/CounterUsingMithril/package-lock.json
+++ b/Examples/CounterUsingMithril/package-lock.json
@@ -1,0 +1,28 @@
+{
+	"name": "counterusingmithril-smalljs",
+	"version": "1.0.0",
+	"lockfileVersion": 3,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "counterusingmithril-smalljs",
+			"version": "1.0.0",
+			"dependencies": {
+				"mithril": "^2.2.15",
+				"tachyons": "^4.12.0"
+			}
+		},
+		"node_modules/mithril": {
+			"version": "2.2.15",
+			"resolved": "https://registry.npmjs.org/mithril/-/mithril-2.2.15.tgz",
+			"integrity": "sha512-jM4bWhyg8FdiSgT+zea9CjDajRnkRK4MggOKTAIEBrYrqRvbnYM0c4hIqn3giomTKSSijt9XadLF/Uz81Sctiw==",
+			"license": "MIT"
+		},
+		"node_modules/tachyons": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/tachyons/-/tachyons-4.12.0.tgz",
+			"integrity": "sha512-2nA2IrYFy3raCM9fxJ2KODRGHVSZNTW3BR0YnlGsLUf1DA3pk3YfWZ/DdfbnZK6zLZS+jUenlUGJsKcA5fUiZg==",
+			"license": "MIT"
+		}
+	}
+}

--- a/Examples/CounterUsingMithril/package.json
+++ b/Examples/CounterUsingMithril/package.json
@@ -1,0 +1,13 @@
+{
+	"name": "counterusingmithril-smalljs",
+	"description": "CounterUsingMithril example app in SmallJS",
+	"version": "1.0.0",
+	"type": "module",
+	"keywords": [
+		"counterusingmithril"
+	],
+	"dependencies": {
+		"mithril": "^2.2.15",
+		"tachyons": "^4.12.0"
+	}
+}

--- a/Examples/CounterUsingMithril/src/CounterUsingMithrilApp.st
+++ b/Examples/CounterUsingMithril/src/CounterUsingMithrilApp.st
@@ -12,15 +12,15 @@ start
 
 buildUI
 	^ Mithril
-		m: 'table#formTable' 
+		m: 'table#formTable.w5.center.tc.br3.ba.bw1.bg-white.b--gray.bs-16px.shadow-10px-grey' 
 		with: (Mithril 
 			m: 'tbody'
 			with: (Mithril
 				m: 'tr'
 				with: (Mithril 
-					m: 'td.title'
+					m: 'td.f3.b.bg-light-blue.mt0.mb0'
 					with: (Mithril 
-						m: 'div.vertical-center'
+						m: 'div.flex.items-center.justify-center'
 						with: (Mithril 
 							m: 'img#logoImage' 
 							with: (Mithril
@@ -40,7 +40,7 @@ buildUI
 				with: (Mithril 
 					m: 'td' 
 					with: (Mithril 
-						m: 'span#counterSpan'
+						m: 'span#counterSpan.b.black.garamond.f1'
 						with: counter value toString
 					) 
 				)
@@ -50,7 +50,7 @@ buildUI
 				with: (Mithril 
 					m: 'td'
 					with: (Mithril 
-						m: 'button#incrementButton' 
+						m: 'button#incrementButton.bg-light-green.br3.f3.w2' 
 						with: (Mithril attribute: 'onclick' value: [self increment]) 
 						with: '+'
 					)
@@ -59,7 +59,7 @@ buildUI
 						with: (Mithril trust: '&nbsp;&nbsp;&nbsp;&nbsp;')
 					)
 					with: (Mithril 
-						m: 'button#resetButton'
+						m: 'button#resetButton.bg-light-coral.br3.f3.w2'
 						with: (Mithril attribute: 'onclick' value: [self reset]) 
 						with: '0'
 					)

--- a/Examples/CounterUsingMithril/src/CounterUsingMithrilApp.st
+++ b/Examples/CounterUsingMithril/src/CounterUsingMithrilApp.st
@@ -12,8 +12,7 @@ start
 
 buildUI
 	^ Mithril
-		m: 'table' 
-		with: (Mithril attribute: 'id' value: 'formTable')
+		m: 'table#formTable' 
 		with: (Mithril 
 			m: 'tbody'
 			with: (Mithril
@@ -23,16 +22,14 @@ buildUI
 					with: (Mithril 
 						m: 'div.vertical-center'
 						with: (Mithril 
-							m: 'img' 
+							m: 'img#logoImage' 
 							with: (Mithril
-								attribute: 'id' value: 'logoImage'
 								attribute: 'src' value: 'logo.png'
 								attribute: 'height' value: '40'
 							)
 						) 
 						with: (Mithril 
-							m: 'span' 
-							with: (Mithril attribute: 'id' value: 'titleMessage')
+							m: 'span#titleMessage' 
 							with: (Mithril trust: '&nbsp;&nbsp;Counter')
 						)
 					)
@@ -43,8 +40,7 @@ buildUI
 				with: (Mithril 
 					m: 'td' 
 					with: (Mithril 
-						m: 'span' 
-						with: (Mithril attribute: 'id' value: 'counterSpan')
+						m: 'span#counterSpan'
 						with: counter value toString
 					) 
 				)
@@ -54,11 +50,8 @@ buildUI
 				with: (Mithril 
 					m: 'td'
 					with: (Mithril 
-						m: 'button' 
-						with: (Mithril 
-							attribute: 'id' value: 'incrementButton' 
-							attribute: 'onclick' value: [self increment]
-						) 
+						m: 'button#incrementButton' 
+						with: (Mithril attribute: 'onclick' value: [self increment]) 
 						with: '+'
 					)
 					with: (Mithril 
@@ -66,11 +59,8 @@ buildUI
 						with: (Mithril trust: '&nbsp;&nbsp;&nbsp;&nbsp;')
 					)
 					with: (Mithril 
-						m: 'button'
-						with: (Mithril 
-							attribute: 'id' value: 'resetButton' 
-							attribute: 'onclick' value: [self reset]
-						) 
+						m: 'button#resetButton'
+						with: (Mithril attribute: 'onclick' value: [self reset]) 
 						with: '0'
 					)
 				)

--- a/Examples/CounterUsingMithril/src/Mithril.st
+++ b/Examples/CounterUsingMithril/src/Mithril.st
@@ -1,5 +1,7 @@
 CLASS Mithril EXTENDS Object MODULE CounterUsingMithrilApp CLASSVARS '' VARS ''
 
+INLINE 'import "../resources-from-npm/mithril.js";'
+
 CLASSMETHODS
 
 mount: aComponent on: aElement

--- a/Examples/CounterUsingMithril/web/default.css
+++ b/Examples/CounterUsingMithril/web/default.css
@@ -4,52 +4,6 @@
     background-color: #F0F0F0;
 }
 
-#formTable {
-	width: 320px;
-	margin-left: auto;
-	margin-right: auto;
-	background-color: white;
-	border: solid gray;
-	border-width: 2px;
-	border-spacing: 16px;
-	border-radius: 10px;
-	text-align: center;
-	box-shadow: 10px 10px 5px grey;
-}
-
-.title {
-	font-size: X-Large;
-	font-weight: bold;
-	background-color: lightblue;
-	margin-top: 0px;
-	margin-bottom: 0px;
-}
-
-#counterSpan {
-    font-family: Garamond;
-	font-size: 100px;
-	font-weight: bold;
-	color: black;
-}
-
-#incrementButton {
-	width: 50px;
-	border-radius: 10px;
-	font-size: X-Large;
-	background-color: lightgreen;
-}
-
-#resetButton {
-	width: 50px;
-	border-radius: 10px;
-	font-size: X-Large;
-	background-color: lightcoral;
-}
-
-.vertical-center
-{
-	display: flex;
-	align-items: center;
-	justify-content: center;
-}
-
+.bs-16px { border-spacing: 16px;}
+.bg-light-coral { background-color: lightcoral; }
+.shadow-10px-grey { box-shadow: 10px 10px 5px grey;}

--- a/Examples/CounterUsingMithril/web/index.html
+++ b/Examples/CounterUsingMithril/web/index.html
@@ -6,8 +6,7 @@
 	<meta charset="utf-8" />
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Counter</title>
-	<script src="https://unpkg.com/mithril@2.2.14/mithril.js"></script>
-	<link rel="stylesheet" href="https://unpkg.com/tachyons@4.12.0/css/tachyons.css"/>
+	<link rel="stylesheet" href="./resources-from-npm/tachyons.css"/>
 	<link rel="stylesheet" href="default.css" type="text/css" />
 	<script src="Script/main.js"></script>
 </head>

--- a/Examples/CounterUsingMithril/web/index.html
+++ b/Examples/CounterUsingMithril/web/index.html
@@ -7,6 +7,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Counter</title>
 	<script src="https://unpkg.com/mithril@2.2.14/mithril.js"></script>
+	<link rel="stylesheet" href="https://unpkg.com/tachyons@4.12.0/css/tachyons.css"/>
 	<link rel="stylesheet" href="default.css" type="text/css" />
 	<script src="Script/main.js"></script>
 </head>

--- a/Examples/install.sh
+++ b/Examples/install.sh
@@ -12,3 +12,4 @@ echo "==== Installing NPM dependencies for examples"
 ./Shop/Server/install.sh
 ./Electron/install.sh
 ./NodeGui/install.sh
+./CounterUsingMithril/install.sh


### PR DESCRIPTION
This PR modifies CounterUsingMithril to use the Tachyons ( https://tachyons.io/ ) CSS library. The Tachyons approach makes it possible to define almost all of the example application's CSS using SmallJS instead of extensively customizing a CSS file like default.css. While you still need to know HTML and CSS using this approach, in theory you could make a large single-page web application editing only SmallJS ".st" files this way.

Tachyons uses an "atomic", "functional", or "utility-first" approach to CSS, where each CSS class makes a small change to a specific component, such as using ".red" to specify an element has the color red or ".b" to make an element bold. This is as opposed to semantic CSS where there are classes that typically make multiple application-specific CSS changes to the styling of an element with that specific class (e.g. ".title"). In theory, atomic/functional CSS makes a large application easier to maintain because there are less interdependence between CSS classes. Also, the long strings of classes typical in functional CSS can be implemented in code with semantic-ish names (e.g. "self cssClassesForButton") if they would benefit from being reusable. Related: https://github.com/dwyl/learn-tachyons

Not everyone agrees that Functional/Atomic CSS is a good idea in all situations though (especially for hand-edited HTML as opposed to code-generated HTML, and also for UX-designer-led large development teams). There are in general also conflicts between design adages of Do Not Repeat Yourself & Separation of Concerns vs. Locality & Flexibility (somewhat similar to the fragile base class issue in Smalltalk). For an example of some Functional CSS criticism, see: https://www.browserlondon.com/blog/2019/06/10/functional-css-perils/

There are other Atomic/Functional CSS libraries. I just picked Tachyons as I know it best -- and using Tachyons also does not require changes to the build process unlike, say, typical use of Tailwind (although Tailwind-lite is an option without a build requirement). Also, there is a less-popular "verbose" version of Tachyons available but I did not use that: https://github.com/tachyons-css/tachyons-verbose

This change is no longer (almost) pixel-perfect with the Counter example. This is because I generally used pre-made Tachyons styles that were close but not exact matches for what was in the example's default.css (e.g. rounded corners now are in some amount of rem instead of exact px). I did need to add three atomic/functional single-purpose CSS styles (e.g. .shadow-10px-grey) in default.css where there was no obvious close Tachyons equivalent. Adding a few such CSS styles as needed to a supplemental application-specific CSS file is still considered part of the Tachyons approach. An alternative could be to add such CSS styles as dynamically-generated CSS using code via an additional library or additional inline JavaScript -- which would avoid the need to edit a CSS file entirely. Or inline CSS could be added with a "style" parameter -- but inline CSS has limitations compared to using styling classes from a separate CSS file including related to media types, pseudo classes, performance, and potentially Content Security Policy (CSP).

This example continues to use the table-oriented layout approach from the original Counter example to make it easier to see the similarities and differences between the two examples. Otherwise, this example code's use of Mithril could be made simpler by eliminating several element definitions by using flexbox more instead of tables with all their required nested elements. Admittedly, the nested keywords don't look quite as elegant yet in Smalltalk keyword syntax compared to nested JavaScript function calls with variable length argument lists and using inline adhoc {} JavaScript objects for parameters. Another approach to reduce some of the nesting would be to use methods to define parts of the interface like the header, count, and buttons, which would then be called to compose the interface. The kludge I made with Mithril.st also has arbitrary small limits right now on how many arguments for nested components or parameters can be used. I'm still wondering if there is a more elegant way to do all that in Smalltalk.

As suggested on a previous PR, this example also now uses local copies of Mithril and Tachyons instead of using copies downloaded from unpkg.com. Unlike using SmallJS with Node which can import npm modules directly as in the Express.st example, using npm modules for a web browser applications seems to require copying files from the npm modules into the web directory somehow (either directly or with some packaging tool which would have been a bigger change than just copying the files). I also could not manage to get Mithril to load cleanly as a local module (without using a packager) so it still adds a "m" global to window, but at least the import is now done in Mithril.st as opposed to index.html.